### PR TITLE
Support for old browsers without Array.isArray support

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -79,7 +79,8 @@ var attachKeys = function (re, keys) {
  * @return {RegExp}
  */
 function pathtoRegexp (path, keys, options) {
-  if (keys && !Array.isArray(keys)) {
+  //Hack to allow old browsers without Array.isArray support to work
+  if (keys && toString.call(keys) !== '[object Array]') {
     options = keys;
     keys = null;
   }
@@ -110,7 +111,8 @@ function pathtoRegexp (path, keys, options) {
     return attachKeys(path, keys);
   }
 
-  if (Array.isArray(path)) {
+  //Hack to allow old browsers without Array.isArray support to work
+  if (toString.call(path) === '[object Array]') {
     // Map array parts into regexps and return their source. We also pass
     // the same keys and options instance into every generation to get
     // consistent matching groups before we join the sources together.

--- a/lib/old_compiler.js
+++ b/lib/old_compiler.js
@@ -1,7 +1,7 @@
 compilePath = function (path, keys, options) {
   if (path instanceof RegExp)
     return path;
-  
+
   path = path
     .replace(/(.)\/$/, '$1')
     .concat(options.strict ? '' : '/?')
@@ -90,7 +90,8 @@ function pathtoRegexp (path, keys, options) {
     return path;
   }
 
-  if (Array.isArray(path)) {
+  //Hack to allow old browsers without Array.isArray support to work
+  if (toString.call(path) === '[object Array]') {
     // Map array parts into regexps and return their source. We also pass
     // the same keys and options instance into every generation to get
     // consistent matching groups before we join the sources together.


### PR DESCRIPTION
Some older browsers do not support Array.isArray. As it appears we are ruling out using underscore in the compiler.js file, I have placed the workaround for lack of Array.isArray in its place for older browser support.
