### PR TITLE
Make Url.resolve include format in the returned value

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -335,7 +335,7 @@ Url.prototype.resolve = function (params, options) {
           var escapedValue = _.map(String(value).split('/'), function (segment) {
             return encodeURIComponent(segment);
           }).join('/');
-          return slash + escapedValue
+          return slash + format + escapedValue;
         }
       )
       .replace(


### PR DESCRIPTION
I've noticed that `Iron.Url.resolve` would drop periods when placed right before named parameters. This was caused by not including `format` argument (i.e. the period) in the returned value. The following example illustrates the issue and the fix:

```javascript

var url = new Url('/posts/:id.:format');

// Before this change:
url.resolve({id: 123, format: 'html'}); // => "/posts/123html"

// After this change:
url.resolve({id: 123, format: 'html'}); // => "/posts/123.html"