### PR TITLE
don't encode query string array square brackets

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -132,7 +132,7 @@ Url.toQueryString = function (queryObject) {
   _.each(queryObject, function (value, key) {
     if (_.isArray(value)) {
       _.each(value, function(valuePart) {
-        result.push(encodeURIComponent(key + '[]') + '=' + encodeURIComponent(valuePart));
+        result.push(encodeURIComponent(key) + '[]=' + encodeURIComponent(valuePart));
       });
     } else {
       result.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));

--- a/test/url_test.js
+++ b/test/url_test.js
@@ -179,8 +179,8 @@ Tinytest.add('Url - resolve', function (test) {
   var path = new Url(paths.explicit);
   test.equal(path.resolve({}), '/posts');
   test.equal(path.resolve({}, {query: {foo: 'bar'}}), '/posts?foo=bar');
-  test.equal(path.resolve({}, {query: {foo: ['bar']}}), '/posts?foo%5B%5D=bar');
-  test.equal(path.resolve({}, {query: {foo: ['bar', 'baz']}}), '/posts?foo%5B%5D=bar&foo%5B%5D=baz');
+  test.equal(path.resolve({}, {query: {foo: ['bar']}}), '/posts?foo[]=bar');
+  test.equal(path.resolve({}, {query: {foo: ['bar', 'baz']}}), '/posts?foo[]=bar&foo[]=baz');
   // no good resolution of this one
   test.equal(path.resolve({}, {query: {foo: []}}), '/posts');
 });


### PR DESCRIPTION
I don't believe there's any reason to encode them, plus it looks much nicer in the address bar