### PR TITLE
bug fix allowing escaped + in URL params

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -8,7 +8,7 @@ var warn = Iron.utils.warn;
 /*****************************************************************************/
 function safeDecodeURIComponent (val) {
   try {
-    return decodeURIComponent(val).replace(/\+/g, ' ');
+    return decodeURIComponent(val.replace(/\+/g, ' '));
   } catch (e) {
     if (e.constructor == URIError) {
       warn("Tried to decode an invalid URI component: " + JSON.stringify(val) + " " + e.stack);
@@ -37,7 +37,7 @@ Url = function (url, options) {
   options = options || {};
   this.options = options;
   this.keys = [];
-  this.regexp = compilePath(url, this.keys, options); 
+  this.regexp = compilePath(url, this.keys, options);
   this._originalPath = url;
   _.extend(this, Url.parse(url));
 };
@@ -55,7 +55,7 @@ Url.normalize = function (url) {
     return url;
   else if (typeof url !== 'string')
     return '/';
-  
+
   var parts = Url.parse(url);
   var pathname = parts.pathname;
 
@@ -155,7 +155,7 @@ Url.parse = function (url) {
 
   //http://tools.ietf.org/html/rfc3986#page-50
   //http://www.rfc-editor.org/errata_search.php?rfc=3986
-  var re = /^(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/; 
+  var re = /^(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/;
 
   var match = url.match(re);
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,7 @@
 Package.describe({
+  name: "iron:url",
   summary: "Url utilities and support for compiling a url into a regular expression.",
-  version: "1.0.6",
+  version: "1.0.7",
   git: "https://github.com/eventedmind/iron-url"
 });
 

--- a/test/url_test.js
+++ b/test/url_test.js
@@ -53,7 +53,7 @@ Tinytest.add('Url - normalize', function (test) {
 
   url = '/items';
   test.equal(Url.normalize(url), '/items');
-  
+
   url = '/items/';
   test.equal(Url.normalize(url), '/items');
 
@@ -169,6 +169,7 @@ Tinytest.add('Url - query params', function (test) {
   var path = new Url(paths.explicit);
   test.isUndefined(path.params('/posts').foo);
   test.equal(path.params('/posts?foo=bar').query.foo, 'bar');
+  test.equal(path.params('/posts?foo=bar%2Bbaz').query.foo, 'bar+baz');
   test.equal(path.params('/posts?foo[]=bar').query.foo, ['bar']);
   test.equal(path.params('/posts?foo%5B%5D=bar').query.foo, ['bar']);
   test.equal(path.params('/posts?foo[]=bar&foo[]=baz').query.foo, ['bar', 'baz']);
@@ -188,7 +189,7 @@ Tinytest.add('Url - resolve', function (test) {
 Tinytest.add('Url - missing params', function (test) {
   var path = new Url(paths.multi);
   test.equal(path.resolve(null), null, 'no params results in null path');
-  
+
   // path.resolve should throw an error if required params are missing
   test.throws(function () {
     path.resolve(null, {throwOnMissingParams: true});


### PR DESCRIPTION
Right now encoded + in a URL gets blindly converted to a space.  A quick change of order in operations still allows the old + for space conversion to work, but also allows properly formatted queries.  

Test included