### PR TITLE
Take Meteor ROOT_URL - setting into account when generating URLs and routing

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,0 +1,5 @@
+1.0.8 - 2015-04-20
+==================
+
+  * Take Meteor ROOT_URL - setting into account when generating URLs.
+  * Upgrade Package to newer API format (added package name to package description, updated function names)

--- a/lib/url.js
+++ b/lib/url.js
@@ -2,6 +2,7 @@
 /* Imports */
 /*****************************************************************************/
 var warn = Iron.utils.warn;
+var assert = Iron.utils.assert;
 
 /*****************************************************************************/
 /* Url */
@@ -244,7 +245,9 @@ Url.parse = function (url) {
  * Returns true if the path matches and false otherwise.
  */
 Url.prototype.test = function (path) {
-  return this.regexp.test(Url.normalize(path));
+  path = Url.normalize(path);
+  path = Url.trimPathPrefixAccordingToMeteorRootUrlSettingsForRouteMatching(path);
+  return this.regexp.test(path);
 };
 
 /**
@@ -252,7 +255,9 @@ Url.prototype.test = function (path) {
  * the given path.
  */
 Url.prototype.exec = function (path) {
-  return this.regexp.exec(Url.normalize(path));
+  path = Url.normalize(path);
+  path = Url.trimPathPrefixAccordingToMeteorRootUrlSettingsForRouteMatching(path);
+  return this.regexp.exec(path);
 };
 
 /**
@@ -369,6 +374,8 @@ Url.prototype.resolve = function (params, options) {
   path = path.replace(/\/+/g, '/'); // Multiple / -> one /
   path = path.replace(/^(.+)\/$/g, '$1'); // Removal of trailing /
 
+  path = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX + path
+
   if (missingParams.length == 0)
     return path;
   else if (options.throwOnMissingParams === true)
@@ -376,6 +383,36 @@ Url.prototype.resolve = function (params, options) {
   else
     return null;
 };
+
+/**
+ * If the entire Meteor project is running in a subdirectory of the webserver (eg. myapp.com/beta/), it's probably being started with setting
+ * the Meteor ROOT_URL - variable to allow for serving from that specific URL, including the subdirectory, as in
+ *
+ * ROOT_URL="http://myapp.com/beta" meteor .
+ *
+ * To be able to match routes containing the prefix ("/beta/" in the example) in front of the main route, we'll trim the part in front of the path
+ * configured via ROOT_URL.
+ *
+ * In short: "/beta/myRoutePath" -> "/myRoutePath".
+ *
+ * This function will be called when a route should be matched.
+ *
+ * Note that on the server the transformation / stripping of the rootUrlPathPrefix is taken care of by meteors' HTTP stack and doesn't mustn't be trimmed there.
+ *
+ * We take care of that inside of the function, but it should probably be taken care of by the calling side.
+ *
+ * @param {String} path
+ * @return {String}
+ */
+Url.trimPathPrefixAccordingToMeteorRootUrlSettingsForRouteMatching = function(path) {
+  var rootUrlPathPrefix = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX;
+  if (Meteor.isClient && rootUrlPathPrefix) {
+    assert(path.substring(0, rootUrlPathPrefix.length) === rootUrlPathPrefix, "Unknown path prefix, expected: '" + rootUrlPathPrefix + "'");
+    path = path.substring(rootUrlPathPrefix.length);
+  }
+  return path;
+};
+
 
 /*****************************************************************************/
 /* Namespacing */

--- a/package.js
+++ b/package.js
@@ -1,22 +1,23 @@
 Package.describe({
   summary: "Url utilities and support for compiling a url into a regular expression.",
-  version: "1.0.7",
+  version: "1.0.8",
+  name: "iron:url",
   git: "https://github.com/eventedmind/iron-url"
 });
 
-Package.on_use(function (api) {
+Package.onUse(function (api) {
   api.use('underscore@1.0.0');
 
   api.use('iron:core@1.0.7');
   api.imply('iron:core');
 
-  api.add_files('lib/compiler.js');
-  api.add_files('lib/url.js');
+  api.addFiles('lib/compiler.js');
+  api.addFiles('lib/url.js');
 });
 
-Package.on_test(function (api) {
+Package.onTest(function (api) {
   api.use('iron:url');
   api.use('tinytest');
   api.use('test-helpers');
-  api.add_files('test/url_test.js', ['client', 'server']);
+  api.addFiles('test/url_test.js');
 });


### PR DESCRIPTION
Hello, I finally got around to update the project I needed this for to IronRouter 1.0+ ... unfortunately the patches I did for the old branch didn't work anymore, so I re-did the "incorporation of the ROOT_URL subdirectory" - fix.

It's not an elegant thing, unfortunately I didn't get around to study the whole Middleware-Concept and if it could help me. I did the patches and tested URL generation and route resolution as far as I could using my project, and it seems to be working alright.

The patch is done solely updating Iron.Url, but of course the Iron Router needs to be updated to reference the newer Iron.Url - package.

Unfortunately I couldn't just create a new fork of Iron-Router using my github account because I already have a fork (and github wants to create the fork with the same name as the original repo, so that's a problem there) and apparently I can't create a pull request from my "custom-cloned and then pushed to gitbub" - clone of IronRouter, but here's the pull request and the changes which would need to be made to IronRouter: https://github.com/DanielDornhardt/iron-router-2/compare/incorporateMeteorROOT_URLSetting?expand=1

It'd be great if somebody would look this over and then merge it into IronRouter proper?

Please let me know if there is something which would need to be changed for this to be accepted, I'd find it very useful and reasonable to have this supported by Iron-Router.

Thanks and best wishes

Daniel :)