### PR TITLE
Make all routes relative to ROOT_URL to support reverse proxies

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -206,7 +206,7 @@ Url.parse = function (url) {
   var path = pathname + (search || '');
   var queryObject = Url.fromQueryString(query);
 
-  var rootUrl = __meteor_runtime_config__.ROOT_URL;;
+  var rootUrl = __meteor_runtime_config__.ROOT_URL;
 
   var href = [
     protocol || '',

--- a/lib/url.js
+++ b/lib/url.js
@@ -159,6 +159,7 @@ Url.parse = function (url) {
 
   var match = url.match(re);
 
+  var pathPrefix = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX;
   var protocol = match[1] ? match[1].toLowerCase() : undefined;
   var hostWithSlashes = match[3];
   var slashes = !!hostWithSlashes;
@@ -181,8 +182,8 @@ Url.parse = function (url) {
   var hostWithPortParts = (host && host.split(':')) || [];
   var hostname = hostWithPortParts[0];
   var port = hostWithPortParts[1];
-  var origin = (protocol && host) ? protocol + '//' + host : undefined;
-  var pathname = match[5];
+  var origin = (protocol && host) ? protocol + '//' + host + pathPrefix : undefined;
+  var pathname = match[5].replace(pathPrefix, '');
   var hash = match[8];
   var originalUrl = url;
 
@@ -205,16 +206,13 @@ Url.parse = function (url) {
   var path = pathname + (search || '');
   var queryObject = Url.fromQueryString(query);
 
-  var rootUrl = [
-    protocol || '',
-    slashes ? '//' : '',
-    hostWithAuth || ''
-  ].join('');
+  var rootUrl = __meteor_runtime_config__.ROOT_URL;;
 
   var href = [
     protocol || '',
     slashes ? '//' : '',
     hostWithAuth || '',
+    pathPrefix || '',
     pathname || '',
     search || '',
     hash || ''
@@ -365,6 +363,8 @@ Url.prototype.resolve = function (params, options) {
       path = path + '#' + hash;
     }
   }
+
+  path = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX + path;
 
   // Because of optional possibly empty segments we normalize path here
   path = path.replace(/\/+/g, '/'); // Multiple / -> one /


### PR DESCRIPTION
Add `ROOT_URL` support.  

Issues: 
- https://github.com/iron-meteor/iron-router/issues/154 - Iron-router behind nginx proxy
- https://github.com/iron-meteor/iron-router/issues/848 - Evaluate route paths relative to ROOT_URL parameter
- https://github.com/iron-meteor/iron-router/issues/875 - Reverse Proxy Nginx
- https://github.com/iron-meteor/iron-router/issues/1454 - app deployed in subfolder instead of root of the domain
