### PR TITLE
Added check data match RegExp part of resolve method

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -333,6 +333,13 @@ Url.prototype.resolve = function (params, options) {
           }
 
           value = _.isFunction(value) ? value.call(params) : value;
+
+          if (capture && !(new RegExp('^' + capture + '$')).test(value)) {
+            throw new Error(
+              'Value "' + value + 
+              '" does not math regexp ' + '(^' + capture + '$)');
+          }
+
           var escapedValue = _.map(String(value).split('/'), function (segment) {
             return encodeURIComponent(segment);
           }).join('/');


### PR DESCRIPTION
If we have some part of URL with regexp part like ```/:category(one|two|three)/:something?``` we can still pass any data to "category". 
I offer to throw error in this case. Anyway resulted url will not handled by router
Such errors will be quickly found with this fix.